### PR TITLE
Fix artboard IDs in LayerCollectionFacade

### DIFF
--- a/sdk/src/layer-collection-facade.ts
+++ b/sdk/src/layer-collection-facade.ts
@@ -550,7 +550,7 @@ export class LayerCollectionFacade {
       return layer.id
     })
 
-    const artboardIds = [...new Set(this.getLayers().map((layer) => layer.id))]
+    const artboardIds = [...new Set(this.getLayers().map((layer) => layer.artboardId))]
     const artboardId = artboardIds.length === 1 ? artboardIds[0] : null
     if (!artboardId) {
       throw new Error(
@@ -605,7 +605,7 @@ export class LayerCollectionFacade {
       return layer.id
     })
 
-    const artboardIds = [...new Set(this.getLayers().map((layer) => layer.id))]
+    const artboardIds = [...new Set(this.getLayers().map((layer) => layer.artboardId))]
     const artboardId = artboardIds.length === 1 ? artboardIds[0] : null
     if (!artboardId) {
       throw new Error(
@@ -660,7 +660,7 @@ export class LayerCollectionFacade {
       return layer.id
     })
 
-    const artboardIds = [...new Set(this.getLayers().map((layer) => layer.id))]
+    const artboardIds = [...new Set(this.getLayers().map((layer) => layer.artboardId))]
     const artboardId = artboardIds.length === 1 ? artboardIds[0] : null
     if (!artboardId) {
       throw new Error(


### PR DESCRIPTION
I'm exporting some layers as an SVG and I kept getting a `The number of artboards from which to export layers must be exactly 1` error even though the layers are all in the same artboard.

This line builds an `artboardIds` variable, but actually just gets the layer ID: https://github.com/opendesigndev/open-design-sdk/blob/master/sdk/src/layer-collection-facade.ts#L663

Changing it so that it gets the layer's artboard ID instead of its own ID.