### PR TITLE
fix bug in passing console to fetch()

### DIFF
--- a/api/src/open-design-api.ts
+++ b/api/src/open-design-api.ts
@@ -835,6 +835,8 @@ export class OpenDesignApi implements IOpenDesignApi {
 
     const res = await this._requestQueue.add(() =>
       fetch(bitmapKey, {
+        console: this._console,
+        ...options,
         cancelToken,
       })
     )

--- a/api/src/open-design-api.ts
+++ b/api/src/open-design-api.ts
@@ -836,7 +836,6 @@ export class OpenDesignApi implements IOpenDesignApi {
     const res = await this._requestQueue.add(() =>
       fetch(bitmapKey, {
         console: this._console,
-        ...options,
         cancelToken,
       })
     )


### PR DESCRIPTION
`OpenDesignApi.getDesignBitmapAssetStream()` calls the `fetch()` function, which takes a `console` parameter. It's present in every other utility call, but it's missing in this one.

This should fix the error where the user sets the logging level above `info` but still gets `info` messages to the console.